### PR TITLE
refactor(kafka): Kafka 메시지 key 변경 및 Consumer DLQ 처리 적용

### DIFF
--- a/src/main/java/com/basestudy/rewards/config/KafkaProducerConfig.java
+++ b/src/main/java/com/basestudy/rewards/config/KafkaProducerConfig.java
@@ -4,7 +4,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.kafka.clients.producer.ProducerConfig;
-import org.apache.kafka.common.serialization.StringSerializer;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -33,12 +32,12 @@ public class KafkaProducerConfig {
     }
 
     @Bean
-    public ProducerFactory<Long, Long> producerFactory() {
+    public ProducerFactory<String, String> producerFactory() {
         return new DefaultKafkaProducerFactory<>(producerConfigs());
     }
 
     @Bean
-    public KafkaTemplate<Long, Long> kafkaTemplate() {
+    public KafkaTemplate<String, String> kafkaTemplate() {
         return new KafkaTemplate<>(producerFactory());
     }
 }

--- a/src/main/java/com/basestudy/rewards/domain/Coupon.java
+++ b/src/main/java/com/basestudy/rewards/domain/Coupon.java
@@ -34,7 +34,7 @@ public class Coupon {
     @Column(name = "id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    //TODO: name을 id로 변경하고 enum class로 관리하기
+    
     @Column(nullable = false)
     private String name;
 

--- a/src/main/java/com/basestudy/rewards/infra/KafkaConsumer.java
+++ b/src/main/java/com/basestudy/rewards/infra/KafkaConsumer.java
@@ -7,6 +7,7 @@ import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
 
 import com.basestudy.rewards.controller.dto.UserCouponDto;
+import com.basestudy.rewards.infra.dto.CouponIssueRequest;
 import com.basestudy.rewards.service.UserCouponService;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -22,13 +23,21 @@ public class KafkaConsumer {
     private static final String TOPIC = "COUPON";
     @Value("${spring.kafka.consumer.group-id}")
     private String groupId;
+    private final ObjectMapper objectMapper;
 
-
-    @KafkaListener(topics = TOPIC, groupId = "${spring.kafka.consumer.group-id}") //동일 그룹내 소비자들 파티션 병렬처리
-    public void listen(ConsumerRecord<Long, Long> record) {
-        Long couponId = record.key();
-        Long userId = record.value();
-        log.debug("kafkaListener : TOPIC = {}, couponID = {}, userId = {}", TOPIC, couponId, userId);
-        userCouponService.saveUserCoupon(couponId, userId);
+    @KafkaListener(topics = TOPIC, groupId = "${spring.kafka.consumer.group-id}") 
+    public void listen(ConsumerRecord<String, String> record) {
+        
+        try{
+            CouponIssueRequest request = objectMapper.readValue(record.value(), CouponIssueRequest.class);
+            log.debug("kafkaListener : couponID = {}, userId = {}", request.getCouponId(), request.getUserId());
+            userCouponService.saveUserCoupon(request.getCouponId(), request.getUserId());
+        } catch (JsonProcessingException e) {
+            log.error("KafkaConsumer::listen - JSON 파싱 오류: {}", e.getMessage(), e);
+            throw new RuntimeException("JSON 파싱 오류-DLQ전송", e);
+        } catch (Exception e) {
+            log.error("KafkaConsumer::listen - 쿠폰 발급 처리 중 오류 발생: {}", e.getMessage(), e);
+            throw new RuntimeException("쿠폰 발급 처리 중 오류 발생-DLQ전송", e);
+        }
     }
 }

--- a/src/main/java/com/basestudy/rewards/infra/KafkaProducer.java
+++ b/src/main/java/com/basestudy/rewards/infra/KafkaProducer.java
@@ -8,6 +8,10 @@ import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.support.SendResult;
 import org.springframework.stereotype.Service;
 
+import com.basestudy.rewards.infra.dto.CouponIssueRequest;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 
@@ -17,12 +21,13 @@ import lombok.extern.log4j.Log4j2;
 public class KafkaProducer {
     
     private static final String TOPIC = "COUPON";
-    private final KafkaTemplate<Long, Long> producer;
+    private final KafkaTemplate<String, String> producer;
+    private final ObjectMapper objectMapper;
 
-    public void sendCouponRequest(Long couponId, Long userId) {
-        ProducerRecord<Long, Long> record = new ProducerRecord<>(TOPIC, couponId, userId);
-        // 쿠폰ID를 키로 설정하여 동일 쿠폰은 항상 같은 파티션으로
-        CompletableFuture<SendResult<Long, Long>> future = producer.send(record);
+    public void sendCouponRequest(Long couponId, Long userId) throws JsonProcessingException {
+        ProducerRecord<String, String> record = new ProducerRecord<>(TOPIC, String.valueOf(userId), objectMapper.writeValueAsString(new CouponIssueRequest(couponId, userId)));
+
+        CompletableFuture<SendResult<String, String>> future = producer.send(record);
             future.whenComplete((result, ex) -> {
                 if (ex == null) {
                     RecordMetadata metadata = result.getRecordMetadata();

--- a/src/main/java/com/basestudy/rewards/infra/RedisRepository.java
+++ b/src/main/java/com/basestudy/rewards/infra/RedisRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Repository;
 
 import com.basestudy.rewards.constants.CouponLockStatus;
-import com.basestudy.rewards.controller.dto.CouponLock;
+import com.basestudy.rewards.infra.dto.CouponLock;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
@@ -26,11 +26,6 @@ public class RedisRepository {
     private int ttlInSeconds;
     @Value("${spring.data.redis.coupon.lock.prefix}")
     private String COUPON_LOCK_PREFIX;
-
-    private void debugLog(String operation, String key, Object value) {
-        log.error("[REDIS DEBUG] {} - key: {}, value: {}, valueType: {}", operation, key, value, (value != null ? value.getClass().getSimpleName() : "null"));
-    }
-
     
     // coupon:lock:{memberId}
     public CouponLock getLockKey(Long memberId) {

--- a/src/main/java/com/basestudy/rewards/infra/dto/CouponIssueRequest.java
+++ b/src/main/java/com/basestudy/rewards/infra/dto/CouponIssueRequest.java
@@ -1,0 +1,13 @@
+package com.basestudy.rewards.infra.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class CouponIssueRequest {
+    private Long couponId;
+    private Long userId;
+}

--- a/src/main/java/com/basestudy/rewards/infra/dto/CouponLock.java
+++ b/src/main/java/com/basestudy/rewards/infra/dto/CouponLock.java
@@ -1,4 +1,4 @@
-package com.basestudy.rewards.controller.dto;
+package com.basestudy.rewards.infra.dto;
 
 import com.basestudy.rewards.constants.CouponLockStatus;
 

--- a/src/main/java/com/basestudy/rewards/service/UserCouponServiceImpl.java
+++ b/src/main/java/com/basestudy/rewards/service/UserCouponServiceImpl.java
@@ -12,14 +12,15 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.basestudy.rewards.ApiResponseWrapper;
 import com.basestudy.rewards.constants.CouponLockStatus;
-import com.basestudy.rewards.controller.dto.CouponLock;
 import com.basestudy.rewards.controller.dto.UserCouponDto;
 import com.basestudy.rewards.domain.Coupon;
 import com.basestudy.rewards.domain.Member;
 import com.basestudy.rewards.infra.KafkaProducer;
 import com.basestudy.rewards.infra.RedisRepository;
+import com.basestudy.rewards.infra.dto.CouponLock;
 import com.basestudy.rewards.repository.UserCouponRepository;
 import com.basestudy.rewards.service.mapper.UserCouponMapper;
+import com.fasterxml.jackson.core.JsonProcessingException;
 
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
@@ -133,7 +134,7 @@ public class UserCouponServiceImpl implements UserCouponService{
         redisRepository.deleteLockKey(memberId);
     }
 
-    private void saveCouponLockAndTriggerKafka(Long couponId, Long memberId) {
+    private void saveCouponLockAndTriggerKafka(Long couponId, Long memberId) throws JsonProcessingException {
         redisRepository.saveLockKeyProcessing(memberId, couponId);
         kafkaProducer.sendCouponRequest(couponId, memberId);
     }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -26,12 +26,12 @@ spring:
     kafka:
         bootstrap-servers: ${KAFKA_URL}
         producer: 
-            key-serializer: org.apache.kafka.common.serialization.LongSerializer
-            value-serializer: org.apache.kafka.common.serialization.LongSerializer
+            key-serializer: org.apache.kafka.common.serialization.StringSerializer
+            value-serializer: org.apache.kafka.common.serialization.StringSerializer
         consumer:
             group-id: ${GROUP_ID}
-            key-deserializer: org.apache.kafka.common.serialization.LongDeserializer
-            value-deserializer: org.apache.kafka.common.serialization.LongDeserializer
+            key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+            value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
             auto-offset-reset: earliest
 logging:
     config: classpath:log4j2.xml


### PR DESCRIPTION
- Redis 선착순 구조로 Kafka 메시지 순서 보장 불필요 → Producer에서 couponId key 대신 userid를 key로 사용
- Consumer에서 DLQ 처리 적용 (JSON 파싱 실패 및 발급 오류 대응)
- Kafka 전송 실패 시 Producer는 수량 복구 및 사용자 락 해제 처리
- 관련 dto 구조 변경